### PR TITLE
workflows-build: add daily build tarballs

### DIFF
--- a/.github/workflows/daily-build-tarballs.yml
+++ b/.github/workflows/daily-build-tarballs.yml
@@ -1,0 +1,90 @@
+name: Daily build tarballs
+
+on:
+  schedule:
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  get-recipes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build aoscbootstrap
+        run: cargo build --release --verbose
+
+      - name: Get recipes from repository
+        uses: actions/github-script@v5
+        id: get-recipes-from-repo
+        with:
+          script: |
+            let args = "";
+            const options = {};
+            options.listeners = {
+              stdout: (data) => {
+                args += data.toString();
+              }
+            };
+            await exec.exec('find', ['recipes', '-maxdepth', '1', '-name', '*.lst', '-not', '-name', '*retro*'], options);
+            const regex = /.*\/(.*).lst/gm;
+            const recipes = args.split('\n').map(arg => regex.exec(arg)).filter(arg => Array.isArray(arg)).map(arg => arg[1]);
+            if (!Array.isArray(recipes) || recipes.length == 0) throw "No recipes to build in the repository!";
+            return recipes;
+
+      - name: Tar files
+        run: |
+          tar -cvf aoscbootstrap.tar \
+            ./target/release/aoscbootstrap \
+            ./{config,contrib,recipes,scripts}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: aoscbootstrap
+          path: aoscbootstrap.tar
+
+    outputs:
+      matrix: ${{steps.get-recipes-from-repo.outputs.result}}
+
+  build-tarballs:
+    needs: get-recipes
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        recipe: ${{fromJson(needs.get-recipes.outputs.matrix)}}
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Download artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: aoscbootstrap
+
+      - name: Un-tar files
+        run: tar -xvf aoscbootstrap.tar .
+
+      - name: Install aoscbootstrap
+        run: |
+          sudo mv target/release/aoscbootstrap /usr/local/bin
+          sudo mkdir -p /usr/local/share/aoscbootstrap
+          sudo mv {config,contrib,recipes,scripts} /usr/local/share/aoscbootstrap
+          sudo ln -s /usr/local/share/aoscbootstrap/contrib/generate-releases.sh /usr/local/bin/generate-releases
+
+      - name: Build tarballs
+        env:
+          RECIPE: ${{matrix.recipe}}
+          PREFIX: '/usr/local'
+        run: sudo -E generate-releases $RECIPE
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: os-amd64_${{matrix.recipe}}
+          path: os-amd64

--- a/contrib/generate-releases.sh
+++ b/contrib/generate-releases.sh
@@ -25,6 +25,7 @@ fi
 
 export TZ='UTC'
 export RETRO=false
+export PREFIX=${PREFIX:-/usr}
 
 mkdir -pv os-${ARCH:-$(dpkg --print-architecture)}
 
@@ -32,24 +33,24 @@ for i in $@; do
     if ! $RETRO; then
         mkdir -pv os-${ARCH:-$(dpkg --print-architecture)}/$i
         aoscbootstrap \
-            --config /usr/share/aoscbootstrap/config/aosc-mainline.toml \
+            --config "$PREFIX"/share/aoscbootstrap/config/aosc-mainline.toml \
             -x \
             --arch ${ARCH:-$(dpkg --print-architecture)} \
             -s \
-                /usr/share/aoscbootstrap/scripts/reset-repo.sh \
-                /usr/share/aoscbootstrap/scripts/enable-nvidia-drivers.sh \
-                /usr/share/aoscbootstrap/scripts/enable-dkms.sh \
-            --include-files /usr/share/aoscbootstrap/recipes/$i.lst \
+                "$PREFIX"/share/aoscbootstrap/scripts/reset-repo.sh \
+                "$PREFIX"/share/aoscbootstrap/scripts/enable-nvidia-drivers.sh \
+                "$PREFIX"/share/aoscbootstrap/scripts/enable-dkms.sh \
+            --include-files "$PREFIX"/share/aoscbootstrap/recipes/$i.lst \
             --export-tar os-${ARCH:-$(dpkg --print-architecture)}/$i/aosc-os_${i}_$(date +%Y%m%d)_${ARCH:-$(dpkg --print-architecture)}.tar.xz \
             stable $i ${REPO:-https://repo.aosc.io/debs}
     else
         mkdir -pv os-${ARCH:-$(dpkg --print-architecture)}/$i
         aoscbootstrap \
-            --config /usr/share/aoscbootstrap/config/aosc-retro.toml \
+            --config "$PREFIX"/share/aoscbootstrap/config/aosc-retro.toml \
             -x \
             --arch ${ARCH:-$(dpkg --print-architecture)} \
-            -s /usr/share/aoscbootstrap/scripts/reset-repo.sh \
-            --include-files /usr/share/aoscbootstrap/recipes/$i.lst \
+            -s "$PREFIX"/share/aoscbootstrap/scripts/reset-repo.sh \
+            --include-files "$PREFIX"/share/aoscbootstrap/recipes/$i.lst \
             --export-tar os-${ARCH:-$(dpkg --print-architecture)}/$i/aosc-os-retro_${i}_$(date +%Y%m%d)_${ARCH:-$(dpkg --print-architecture)}.tar.xz \
             stable $i ${REPO:-https://repo.aosc.io/debs-retro}
     fi


### PR DESCRIPTION
Tested on own fork.

### Problem

- On Ubuntu, `dpkg` fails in a strange way.
  - `ls` shows `/proc` is mounted.

```
Setting up php7 (7.4.19) ...
/proc/ is not mounted, but required for successful operation of systemd-tmpfiles. Please mount /proc/. Alternatively, consider using the --root= or --image= switches.
dpkg: error processing package php7 (--configure):
 installed php7 package post-installation script subprocess returned error exit status 1
```
