### PR TITLE
network: create GNU coreutils compatible checksum

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -23,7 +23,7 @@ fn sha256sum_file(path: &Path) -> Result<String> {
 
 pub(crate) fn sha256sum_file_tag(path: &Path) -> Result<()> {
     let mut f = File::create(format!("{}.sha256sum", path.to_string_lossy()))?;
-    f.write_all(format!("{} *{}", sha256sum_file(&path), path.to_string_lossy()).as_bytes());
+    f.write_all(format!("{} *{}", sha256sum_file(&path)?, path.to_string_lossy()).as_bytes())?;
 
     Ok(())
 }


### PR DESCRIPTION
Change the format of sha256 file to what GNU coreutils uses[^1].

[^1]: https://manpages.ubuntu.com/manpages/jammy/en/man1/sha256sum.1.html