### PR TITLE
WSL Fixes

### DIFF
--- a/contrib/generate-releases.sh
+++ b/contrib/generate-releases.sh
@@ -59,6 +59,8 @@ for i in $@; do
 					--arch ${ARCH:-$(dpkg --print-architecture)} \
 					-s \
 						/usr/share/aoscbootstrap/scripts/reset-repo.sh \
+					-s \
+						/usr/share/aoscbootstrap/scripts/wsl-machine-id-hack.sh \
 					--include-files /usr/share/aoscbootstrap/recipes/$i.lst \
 					--export-tar-gz os-${ARCH:-$(dpkg --print-architecture)}/$i/aosc-os_${i}_$(date +%Y%m%d)_${ARCH:-$(dpkg --print-architecture)}.tar.gz
 			fi

--- a/contrib/generate-releases.sh
+++ b/contrib/generate-releases.sh
@@ -59,10 +59,6 @@ for i in $@; do
 					--arch ${ARCH:-$(dpkg --print-architecture)} \
 					-s \
 						/usr/share/aoscbootstrap/scripts/reset-repo.sh \
-					-s \
-						/usr/share/aoscbootstrap/scripts/enable-nvidia-drivers.sh \
-					-s \
-						/usr/share/aoscbootstrap/scripts/enable-dkms.sh \
 					--include-files /usr/share/aoscbootstrap/recipes/$i.lst \
 					--export-tar-gz os-${ARCH:-$(dpkg --print-architecture)}/$i/aosc-os_${i}_$(date +%Y%m%d)_${ARCH:-$(dpkg --print-architecture)}.tar.gz
 			fi

--- a/scripts/wsl-machine-id-hack.sh
+++ b/scripts/wsl-machine-id-hack.sh
@@ -1,0 +1,2 @@
+echo "Creating an empty /etc/machine-id file for WSL ..."
+touch /etc/machine-id


### PR DESCRIPTION
- fix(wsl): add a script to create an empty /etc/machine-id
    - The current WSL version seems to generate a race condition in which the /etc/machine-id file may fail to generate during the first "boot."
- fix(contrib/generate-releases.sh): (WSL) disable unneeded NVIDIA and DKMS scripts

Co-authored-by: Lain "Fearyncess" Yang <fsf@live.com>