### PR TITLE
feat: add allow-existing flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,6 +54,9 @@ struct Args {
     /// Limit the number of parallel jobs
     #[clap(short = 'j', long)]
     jobs: Option<usize>,
+    /// Allow existing target directory
+    #[clap(long = "allow-existing", default_value = "false")]
+    allow_existing: bool,
     /// Export a xz compressed tar archive
     #[clap(long = "export-tar-xz")]
     tar_xz: Option<String>,
@@ -309,9 +312,10 @@ fn main() {
         .unwrap();
     let client = network::make_new_client().unwrap();
     let target_path = Path::new(target);
+    let allow_existing = args.allow_existing;
     let archive_path = target_path.join("var/cache/apt/archives");
     let threads = args.jobs.unwrap_or_else(num_cpus::get);
-    if target_path.exists() {
+    if target_path.exists() && !allow_existing {
         panic!(
             "{}",
             "Target already exists. Please remove it first."


### PR DESCRIPTION
In certain scenarios (such as QEMU image building), directories need to be prepared in advance to facilitate the mounting of a specific directory structure. Add `allow-existing flag` (disabled by default) to address this issue.