### PR TITLE
recipes/starfive: Add starfive-jh7110 recipes

### DIFF
--- a/recipes/mainline/starfive-jh7110-common.lst
+++ b/recipes/mainline/starfive-jh7110-common.lst
@@ -1,0 +1,5 @@
+firmware-free
+firmware-nonfree
+jh7110-pvr-blobs
+linux+kernel+starfive+jh7110
+mesa-pvr-ddk119

--- a/recipes/starfive/base-jh7110-starfive-visionfive-2-v1.3b.lst
+++ b/recipes/starfive/base-jh7110-starfive-visionfive-2-v1.3b.lst
@@ -1,0 +1,2 @@
+%include ../mainline/base-common.lst
+%include ../mainline/starfive-jh7110-common.lst

--- a/recipes/starfive/desktop-jh7110-starfive-visionfive-2-v1.3b.lst
+++ b/recipes/starfive/desktop-jh7110-starfive-visionfive-2-v1.3b.lst
@@ -1,0 +1,2 @@
+%include ../mainline/kde-common.lst
+%include ../mainline/starfive-jh7110-common.lst

--- a/recipes/starfive/server-jh7110-starfive-visionfive-2-v1.3b.lst
+++ b/recipes/starfive/server-jh7110-starfive-visionfive-2-v1.3b.lst
@@ -1,0 +1,2 @@
+%include ../mainline/server-common.lst
+%include ../mainline/starfive-jh7110-common.lst


### PR DESCRIPTION
This PR adds bootstrapping recipes for StarFive JH7110 devices (currently only VisionFive2).