### PR TITLE
recipes/rpi64: remove rpi-userland

### DIFF
--- a/recipes/mainline/rpi64-common.lst
+++ b/recipes/mainline/rpi64-common.lst
@@ -1,4 +1,3 @@
 linux+kernel+rpi64+lts
 linux-kernel-rpi64-lts
 rpi-firmware-boot
-rpi-userland


### PR DESCRIPTION
rpi-userland is deprecated.
See https://github.com/raspberrypi/userland