### PR TITLE
QEMU user emulation improvements

### DIFF
--- a/src/guest.rs
+++ b/src/guest.rs
@@ -102,7 +102,7 @@ fn nspawn_do(target: &str, args: &[&str]) -> Result<()> {
         .stderr(Stdio::null())
         .spawn()?;
     eprintln!("Waiting for the container ...");
-    wait_for_container(&mut child, &ns_name, 10)?;
+    wait_for_container(&mut child, &ns_name, 60)?;
     let status = execute_container_command(&ns_name, args)?;
 
     eprintln!("Powering off the container ...");

--- a/src/guest.rs
+++ b/src/guest.rs
@@ -106,8 +106,8 @@ fn nspawn_do(target: &str, args: &[&str]) -> Result<()> {
     let status = execute_container_command(&ns_name, args)?;
 
     eprintln!("Powering off the container ...");
-    Command::new("machinectl")
-        .args(["poweroff", &ns_name])
+    Command::new("systemctl")
+        .args(["-M", &ns_name, "poweroff"])
         .status()?;
 
     if status != 0 {


### PR DESCRIPTION
This PR does the following:

- Wait longer for the container to boot up.
- Use `systemctl -M poweroff` to shut down the container, instead of `machinectl poweroff`.