### PR TITLE
fix: disable GNUTYPE_SPARSE to fix docker build

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -126,6 +126,7 @@ fn create_progress_bar(size: u64, no_progressbar: bool) -> Result<ProgressBar> {
 
 fn build_tarball_stream<W: Write>(stream: W, root: &Path) -> Result<Builder<W>, anyhow::Error> {
     let mut builder = Builder::new(stream);
+    builder.sparse(false); // otherwise some docker version may complain: Unhandled tar header type 83
     builder.mode(tar::HeaderMode::Complete);
     builder.follow_symlinks(false);
     builder.append_dir_all(".", root)?;


### PR DESCRIPTION
https://github.com/moby/moby/issues/4066

and

https://github.com/dongdigua/aosc-os-docker-files/actions/runs/15941041853/job/44969100053