### PR TITLE
fix: fix sources-list CLI argument again

### DIFF
--- a/src/network.rs
+++ b/src/network.rs
@@ -73,7 +73,7 @@ pub fn fetch_manifests(
     branch: &str,
     topics: &[String],
     arches: &[&str],
-    comps: Vec<String>,
+    comps: &Vec<String>,
     root: &Path,
 ) -> Result<Vec<String>> {
     let manifests = Arc::new(Mutex::new(Vec::new()));


### PR DESCRIPTION
Follow-up: #43

Changes:
- [Breaking] `main` will no longer be always included in components, when caller specifies `--comps` without `main`.
- Handle default values with Clap to avoid further bugs related to default values.

r? @dongdigua